### PR TITLE
Clean and config args to filter through repos

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,13 @@ CURRENT
 
 - [dev]: support for tmuxp ``before_script`` to set up local virtualenv +
   dependencies.
+- [dev]: Clean up ``__init__.py`` imports
+- [internals]: move :meth:`update` to :meth:`update_dict` in ``utils``.
+- [cli]: ``-d`` / ``--dirmatch`` for matching directories, accepts
+  `fnmatch`_ \'s.
+- [cli]: ``-r`` / ``--repomatch`` for matching directories, accepts
+  `fnmatch`_ \'s.
+- [cli]: ``-c`` / ``--config`` YAML / JSON file of repositories
 
 0.0.8.4
 -------

--- a/vcspull/__init__.py
+++ b/vcspull/__init__.py
@@ -22,12 +22,17 @@ __email__ = 'tony@git-pull.com'
 __license__ = 'BSD'
 __copyright__ = 'Copyright 2013 Tony Narlock'
 
-from .util import expand_config, get_repos, mkdir_p, run, scan, which
-from .log import LogFormatter, DebugLogFormatter, RepoLogFormatter, \
-    RepoFilter
-from .cli import ConfigFileCompleter, command_load, find_configs, get_parser, \
-    get_repos_new, in_dir, is_config_file, load_configs, main, scan_repos, \
-    setup_logger, update, validate_schema
+from .util import (
+    expand_config, get_repos, mkdir_p, run, scan, which, update_dict
+)
+from .log import (
+    LogFormatter, DebugLogFormatter, RepoLogFormatter, RepoFilter
+)
+from .cli import (
+    ConfigFileCompleter, command_load, find_configs, get_parser,
+    get_repos_new, in_dir, is_config_file, load_configs, main, scan_repos,
+    setup_logger, validate_schema
+)
 
 # Set default logging handler to avoid "No handler found" warnings.
 import logging

--- a/vcspull/testsuite/__init__.py
+++ b/vcspull/testsuite/__init__.py
@@ -18,8 +18,12 @@ from __future__ import absolute_import, division, print_function, \
     with_statement, unicode_literals
 
 import logging
-import unittest
 import sys
+
+try:
+    import unittest2 as unittest
+except ImportError:  # Python 2.7
+    import unittest
 
 from .. import log
 from .._compat import string_types, PY2, reraise

--- a/vcspull/testsuite/helpers.py
+++ b/vcspull/testsuite/helpers.py
@@ -46,11 +46,6 @@ class ConfigTest(unittest.TestCase):
         self.TMP_DIR = tempfile.mkdtemp(suffix='vcspull')
 
 
-
-
-
-
-
 class ConfigExamples(ConfigTest):
 
     """ConfigExamples mixin that creates test directory + sample configs."""

--- a/vcspull/testsuite/repo_hg.py
+++ b/vcspull/testsuite/repo_hg.py
@@ -9,9 +9,9 @@ from __future__ import absolute_import, division, print_function, \
     with_statement, unicode_literals
 
 import os
-import unittest
 import logging
 
+from . import unittest
 from .helpers import ConfigTest
 from ..repo import Repo
 from ..util import run, which

--- a/vcspull/testsuite/repo_object.py
+++ b/vcspull/testsuite/repo_object.py
@@ -18,6 +18,60 @@ from ..util import expand_config, get_repos, run
 from .helpers import ConfigExamples, RepoTest
 
 
+class GetReposTest(ConfigExamples, unittest.TestCase):
+
+    def test_filter_dir(self):
+        """``get_repos`` filter by dir"""
+        config = self.config_dict_expanded
+
+        repo_list = get_repos(
+            self.config_dict_expanded,
+            dirmatch="*github_project*"
+        )
+
+        self.assertEqual(len(repo_list), 1)
+        repo_key = '{TMP_DIR}/github_projects/'.format(
+            TMP_DIR=self.TMP_DIR,
+        )
+        exected_repo = self.config_dict_expanded[repo_key]['kaptan']
+        for r in repo_list:
+            self.assertEqual(r['name'], 'kaptan')
+
+    def test_filter_name(self):
+        """``get_repos`` filter by name"""
+        config = self.config_dict_expanded
+
+        repo_list = get_repos(
+            self.config_dict_expanded,
+            namematch=".vim"
+        )
+
+        self.assertEqual(len(repo_list), 1)
+        repo_key = '{TMP_DIR}'.format(
+            TMP_DIR=self.TMP_DIR,
+        )
+        exected_repo = self.config_dict_expanded[repo_key]['.vim']
+        for r in repo_list:
+            self.assertEqual(r['name'], '.vim')
+
+    def test_filter_vcs(self):
+        """``get_repos`` filter by vcs"""
+        config = self.config_dict_expanded
+
+        repo_list = get_repos(
+            self.config_dict_expanded,
+            repomatch="*kernel.org*"
+        )
+
+        self.assertEqual(len(repo_list), 1)
+        repo_key = '{TMP_DIR}/study/'.format(
+            TMP_DIR=self.TMP_DIR,
+        )
+        exected_repo = self.config_dict_expanded[repo_key]['linux']
+        for r in repo_list:
+            self.assertEqual(r['name'], 'linux')
+
+
 class ConfigToObjectTest(ConfigExamples):
 
     """TestCase for converting config (dict) into Repo object."""
@@ -143,6 +197,7 @@ class EnsureMakeDirsRecursively(RepoTest):
 
 def suite():
     suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(GetReposTest))
     suite.addTest(unittest.makeSuite(ConfigToObjectTest))
     suite.addTest(unittest.makeSuite(EnsureMakeDirsRecursively))
     return suite

--- a/vcspull/testsuite/repo_svn.py
+++ b/vcspull/testsuite/repo_svn.py
@@ -11,8 +11,9 @@ from __future__ import absolute_import, division, print_function, \
 import os
 import logging
 import tempfile
-import unittest
 
+
+from . import unittest
 from .helpers import RepoTest
 from ..repo import Repo
 from ..util import run, which


### PR DESCRIPTION
Move config arguments to -c, add -r / --repomatch, -d / --dirmatch and p...ositional argument namematch, which all accept fnmatch-style args. Add tests to get_repos.