### PR TITLE
Improve svn and git support

### DIFF
--- a/vcspull/repo/base.py
+++ b/vcspull/repo/base.py
@@ -129,7 +129,7 @@ class BaseRepo(collections.MutableMapping, RepoLoggingAdapter):
 
     def run(
         self, cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        env=os.environ.copy(), cwd=None, stream_stderr=True, *args, **kwargs
+        env=os.environ.copy(), cwd=None, stream_stderr=True, log_stdout=True, *args, **kwargs
     ):
         process = subprocess.Popen(
             cmd,
@@ -152,9 +152,11 @@ class BaseRepo(collections.MutableMapping, RepoLoggingAdapter):
                 else:
                     self.show_progress("%s" % err)
 
-            self.end_progress('%s' % (console_to_str(process.stdout.read())))
+            process.stdout_data = console_to_str(process.stdout.read())
+            self.end_progress('%s' % process.stdout_data if log_stdout else '')
         else:
-            self.info('%s' % (process.stdout.read()))
+            process.stdout_data = process.stdout.read()
+            self.info('%s' % process.stdout_data)
 
         process.stderr.close()
         process.stdout.close()

--- a/vcspull/repo/base.py
+++ b/vcspull/repo/base.py
@@ -139,7 +139,7 @@ class BaseRepo(collections.MutableMapping, RepoLoggingAdapter):
         )
 
         if stream_stderr:
-            self.start_progress(' '.join(cmd))
+            self.start_progress(' '.join(["'%s'" % arg for arg in cmd]))
             while True:
 
                 err = console_to_str(process.stderr.read(128))

--- a/vcspull/repo/git.py
+++ b/vcspull/repo/git.py
@@ -115,6 +115,7 @@ class GitRepo(BaseRepo):
             - ``git+https://github.com/tony/vcspull.git``
             - ``git+ssh://git@github.com:tony/vcspull.git``
         :type url: str
+
         :param remotes: list of remotes in dict format::
 
             [{
@@ -122,7 +123,12 @@ class GitRepo(BaseRepo):
             "url": "https://github.com/tony/vim-config.git"
             }]
         :type remotes: list
+
+        :param shallow: tell Git to clone with ``--depth 1`` (default False)
+        :type shallow: bool
         """
+        if 'shallow' not in kwargs:
+            kwargs['shallow'] = False
         BaseRepo.__init__(self, url, **kwargs)
 
         self['remotes'] = remotes
@@ -169,9 +175,15 @@ class GitRepo(BaseRepo):
         self.check_destination()
 
         url, rev = self.get_url_rev()
+
+        cmd = ['git', 'clone', '--progress']
+        if self.attributes['shallow']:
+            cmd.extend(['--depth', '1'])
+        cmd.extend([url, self['path']])
+
         self.info('Cloning.')
         self.run(
-            ['git', 'clone', '--progress', url, self['path']],
+            cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=os.environ.copy(), cwd=self['path'],

--- a/vcspull/repo/git.py
+++ b/vcspull/repo/git.py
@@ -126,9 +126,14 @@ class GitRepo(BaseRepo):
 
         :param shallow: tell Git to clone with ``--depth 1`` (default False)
         :type shallow: bool
+
+        :param tls_verify: Should certificate for https be checked (default False)
+        :type tls_verify: bool
         """
         if 'shallow' not in kwargs:
             kwargs['shallow'] = False
+        if 'tls_verify' not in kwargs:
+            kwargs['tls_verify'] = False
         BaseRepo.__init__(self, url, **kwargs)
 
         self['remotes'] = remotes
@@ -179,6 +184,8 @@ class GitRepo(BaseRepo):
         cmd = ['git', 'clone', '--progress']
         if self.attributes['shallow']:
             cmd.extend(['--depth', '1'])
+        if self.attributes['tls_verify']:
+            cmd.extend(['-c', 'http.sslVerify=false'])
         cmd.extend([url, self['path']])
 
         self.info('Cloning.')

--- a/vcspull/repo/git.py
+++ b/vcspull/repo/git.py
@@ -124,14 +124,14 @@ class GitRepo(BaseRepo):
             }]
         :type remotes: list
 
-        :param shallow: tell Git to clone with ``--depth 1`` (default False)
-        :type shallow: bool
+        :param git_shallow: tell Git to clone with ``--depth 1`` (default False)
+        :type git_shallow: bool
 
         :param tls_verify: Should certificate for https be checked (default False)
         :type tls_verify: bool
         """
-        if 'shallow' not in kwargs:
-            kwargs['shallow'] = False
+        if 'git_shallow' not in kwargs:
+            kwargs['git_shallow'] = False
         if 'tls_verify' not in kwargs:
             kwargs['tls_verify'] = False
         BaseRepo.__init__(self, url, **kwargs)
@@ -182,7 +182,7 @@ class GitRepo(BaseRepo):
         url, rev = self.get_url_rev()
 
         cmd = ['git', 'clone', '--progress']
-        if self.attributes['shallow']:
+        if self.attributes['git_shallow']:
             cmd.extend(['--depth', '1'])
         if self.attributes['tls_verify']:
             cmd.extend(['-c', 'http.sslVerify=false'])

--- a/vcspull/repo/svn.py
+++ b/vcspull/repo/svn.py
@@ -43,6 +43,12 @@ class SubversionRepo(BaseRepo):
             - ``svn+svn://svn.myproject.org/svn/MyProject``
             - ``svn+http://svn.myproject.org/svn/MyProject/trunk@2019``
         :type url: str
+
+        :param username: username to use for checkout and update
+        :type username: str or None
+
+        :param password: password to use for checkout and update
+        :type password: str or None
         """
         BaseRepo.__init__(self, url, **kwargs)
 

--- a/vcspull/repo/svn.py
+++ b/vcspull/repo/svn.py
@@ -49,7 +49,12 @@ class SubversionRepo(BaseRepo):
 
         :param password: password to use for checkout and update
         :type password: str or None
+
+        :param svn_trust_cert: trust the Subversion server site certificate (default False)
+        :type svn_trust_cert: bool
         """
+        if 'svn_trust_cert' not in kwargs:
+            kwargs['svn_trust_cert'] = False
         BaseRepo.__init__(self, url, **kwargs)
 
     def _user_pw_args(self):
@@ -65,6 +70,8 @@ class SubversionRepo(BaseRepo):
         url, rev = self.get_url_rev()
 
         cmd = ['svn', 'checkout', '-q', url, '--non-interactive']
+        if self.attributes['svn_trust_cert']:
+            cmd.append('--trust-server-cert')
         cmd.extend(self._user_pw_args())
         cmd.extend(get_rev_options(url, rev))
         cmd.append(self['path'])

--- a/vcspull/repo/svn.py
+++ b/vcspull/repo/svn.py
@@ -43,7 +43,7 @@ class SubversionRepo(BaseRepo):
 
         url, rev = self.get_url_rev()
 
-        cmd = ['svn', 'checkout', '-q', url]
+        cmd = ['svn', 'checkout', '-q', url, '--non-interactive']
         cmd.extend(get_rev_options(url, rev))
         cmd.append(self['path'])
 

--- a/vcspull/repo/svn.py
+++ b/vcspull/repo/svn.py
@@ -42,10 +42,13 @@ class SubversionRepo(BaseRepo):
         self.check_destination()
 
         url, rev = self.get_url_rev()
-        get_rev_options(url, rev)
+
+        cmd = ['svn', 'checkout', '-q', url]
+        cmd.extend(get_rev_options(url, rev))
+        cmd.append(self['path'])
 
         self.run(
-            ['svn', 'checkout', '-q', url, self['path']],
+            cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=os.environ.copy(),
@@ -120,8 +123,10 @@ class SubversionRepo(BaseRepo):
 
             url, rev = self.get_url_rev()
 
+            cmd = ['svn', 'update']
+            cmd.extend(get_rev_options(url, rev))
             self.run(
-                ['svn', 'update'],
+                cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 env=os.environ.copy(), cwd=self['path'],

--- a/vcspull/repo/svn.py
+++ b/vcspull/repo/svn.py
@@ -36,6 +36,14 @@ class SubversionRepo(BaseRepo):
     schemes = ('svn')
 
     def __init__(self, url, **kwargs):
+        """A svn repository.
+
+        :param url: URL in pip vcs format:
+
+            - ``svn+svn://svn.myproject.org/svn/MyProject``
+            - ``svn+http://svn.myproject.org/svn/MyProject/trunk@2019``
+        :type url: str
+        """
         BaseRepo.__init__(self, url, **kwargs)
 
     def _user_pw_args(self):

--- a/vcspull/repo/svn.py
+++ b/vcspull/repo/svn.py
@@ -38,12 +38,20 @@ class SubversionRepo(BaseRepo):
     def __init__(self, url, **kwargs):
         BaseRepo.__init__(self, url, **kwargs)
 
+    def _user_pw_args(self):
+        args = []
+        for param_name in ['username', 'password']:
+            if param_name in self.attributes:
+                args.extend(['--' + param_name, self.attributes[param_name]])
+        return args
+
     def obtain(self, quiet=None):
         self.check_destination()
 
         url, rev = self.get_url_rev()
 
         cmd = ['svn', 'checkout', '-q', url, '--non-interactive']
+        cmd.extend(self._user_pw_args())
         cmd.extend(get_rev_options(url, rev))
         cmd.append(self['path'])
 
@@ -124,7 +132,9 @@ class SubversionRepo(BaseRepo):
             url, rev = self.get_url_rev()
 
             cmd = ['svn', 'update']
+            cmd.extend(self._user_pw_args())
             cmd.extend(get_rev_options(url, rev))
+
             self.run(
                 cmd,
                 stdout=subprocess.PIPE,

--- a/vcspull/repo/svn.py
+++ b/vcspull/repo/svn.py
@@ -44,11 +44,11 @@ class SubversionRepo(BaseRepo):
             - ``svn+http://svn.myproject.org/svn/MyProject/trunk@2019``
         :type url: str
 
-        :param username: username to use for checkout and update
-        :type username: str or None
+        :param svn_username: username to use for checkout and update
+        :type svn_username: str or None
 
-        :param password: password to use for checkout and update
-        :type password: str or None
+        :param svn_password: password to use for checkout and update
+        :type svn_password: str or None
 
         :param svn_trust_cert: trust the Subversion server site certificate (default False)
         :type svn_trust_cert: bool
@@ -59,9 +59,9 @@ class SubversionRepo(BaseRepo):
 
     def _user_pw_args(self):
         args = []
-        for param_name in ['username', 'password']:
+        for param_name in ['svn_username', 'svn_password']:
             if param_name in self.attributes:
-                args.extend(['--' + param_name, self.attributes[param_name]])
+                args.extend(['--' + param_name[4:], self.attributes[param_name]])
         return args
 
     def obtain(self, quiet=None):


### PR DESCRIPTION
This PR updates vcspull so that it can support:
* git:
 * checkout of specific revision or git_tag with exhaustive error checking
 * specifying options `git_remote_name` and `tls_verify` as keyword args to `create_repo` 
* svn:
 * specifying `svn_username` and `svn_password` as keyword args to `create_repo` (original behavior where username/password are extracted from url is still available)
 * checking out a specific svn revision
 * specifying  `svn_trust_cert` as keyword args to `create_repo` 

Remaining:
* [ ] Mock tests for svn and git

